### PR TITLE
Load current User as model for authenticated route

### DIFF
--- a/app/adapters/user.js
+++ b/app/adapters/user.js
@@ -1,0 +1,12 @@
+import ApplicationAdapter from './application';
+import fetch from 'fetch';
+
+export default ApplicationAdapter.extend({
+  queryRecord(store, type, query) {
+    if (query.current) {
+      return fetch(`${this.urlPrefix()}/users/current`).then(response =>  response.json());
+    }
+
+    return this._super(...arguments);
+  }
+});

--- a/app/routes/authenticated.js
+++ b/app/routes/authenticated.js
@@ -2,5 +2,9 @@ import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Route.extend(AuthenticatedRouteMixin, {
-  authenticationRoute: 'sign-in'
+  authenticationRoute: 'sign-in',
+
+  model() {
+    return this.get('store').queryRecord('user', { current: true });
+  }
 });

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -30,6 +30,9 @@ export default function() {
 
     return new Response(400);
   });
+  this.get('/users/current', ({users}) => {
+    return users.find(1);
+  });
 
   // CRUD
 

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -1,0 +1,6 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  email: faker.internet.email(),
+  name: faker.internet.userName()
+});

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -1,6 +1,9 @@
 import { sampleSize } from 'lodash';
 
 export default function(server) {
+  server.create('user');
+
+  // Prior demo; replace with realistic Projects and Genres
   let projects = server.createList('project', 2);
   let genres = server.createList('genre', 5);
 

--- a/tests/acceptance/genres-crud-test.js
+++ b/tests/acceptance/genres-crud-test.js
@@ -8,6 +8,10 @@ module('Acceptance | genres CRUD', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
+  hooks.beforeEach(function() {
+    this.server.create('user');
+  });
+
   test('list genres', async function(assert) {
     let genreCount = 3;
     let genres = this.server.createList('genre', genreCount);

--- a/tests/acceptance/sign-in-test.js
+++ b/tests/acceptance/sign-in-test.js
@@ -8,13 +8,15 @@ module('Acceptance | sign in', function(hooks) {
   setupMirage(hooks);
 
   test('Basic Authentication', async function(assert) {
+    let user = this.server.create('user');
+
     await visit('/sign-in');
 
     await click('[data-test-sign-in-submit]');
 
     assert.equal(currentURL(), '/sign-in', 'does not submit blank form');
 
-    await fillIn('input[data-test-form-for--input=email]', 'user@example.com');
+    await fillIn('input[data-test-form-for--input=email]', user.email);
     await fillIn('input[data-test-form-for--input=password]', 'password');
     await click('[data-test-sign-in-submit]');
 

--- a/tests/unit/adapters/user-test.js
+++ b/tests/unit/adapters/user-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | user', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let adapter = this.owner.lookup('adapter:user');
+    assert.ok(adapter);
+  });
+});


### PR DESCRIPTION
This is a convenience PR to load the current logged-in User as the model for the `authenticated` route. This allows any route nested under the `authenticated` route to access the current logged-in User with [`modelFor`](https://emberjs.com/api/ember/3.1/classes/Route/methods/modelFor?anchor=modelFor) as follows:

```js
// app/routes/authenticated/*.js
import Route from '@ember/routing/route';

export default Route.extend({
  model() {
    let user = this.modelFor('authenticated');
    // Do something here using the logged-in User
  }
});
```

I'm introducing this ahead of my current User profile work as it sounds like it will benefit @nanojezra's current Projects work as well.