### PR TITLE
Enable jQuery

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -9,9 +9,6 @@ module.exports = function(defaults) {
       importBootstrapFont: false,
       importBootstrapCSS: false
     },
-    vendorFiles: {
-      'jquery.js': null
-    },
     'ember-font-awesome': {
       useScss: true, // for ember-cli-sass
       useLess: true  // for ember-cli-less

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-modal-dialog": "^3.0.0-beta.0",
     "ember-moment": "^7.7.0",
-    "ember-native-dom-helpers": "^0.6.2",
     "ember-power-select": "^2.0.0-beta.3",
     "ember-power-select-with-create": "^0.6.0",
     "ember-resolver": "^4.0.0",

--- a/tests/integration/components/validated-input-test.js
+++ b/tests/integration/components/validated-input-test.js
@@ -1,8 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { blur, find, findAll, focus, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { find, findAll, triggerEvent } from 'ember-native-dom-helpers';
 
 module('Integration | Component | validated-input', function(hooks) {
   setupRenderingTest(hooks);
@@ -37,7 +36,8 @@ module('Integration | Component | validated-input', function(hooks) {
     assert.equal(find('[data-test-error-message]').textContent, errorMessage, 'shows error message after attempted form submission');
 
     await this.set('hasAttemptedSubmit', false);
-    await triggerEvent(`input[name=${key}]`, 'focusout');
+    await focus(`input[name=${key}]`);
+    await blur(`input[name=${key}]`);
 
     assert.equal(findAll('[data-test-error-message]').length, 1, 'does show error after input blur');
     assert.equal(find('[data-test-error-message]').textContent, errorMessage, 'shows error message after input blur');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3548,13 +3548,6 @@ ember-moment@^7.7.0:
     ember-getowner-polyfill "^2.0.1"
     ember-macro-helpers "^0.17.0"
 
-ember-native-dom-helpers@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.6.2.tgz#ad1f82d64ac9abdd612022f4f390bdb6653b3d39"
-  dependencies:
-    broccoli-funnel "^1.1.0"
-    ember-cli-babel "^6.6.0"
-
 ember-popper@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/ember-popper/-/ember-popper-0.9.0.tgz#ec211e116bb3c4fb70a770e75134b94ddda079b5"


### PR DESCRIPTION
Removing `ember-native-dom-helpers` as the functionality it provides is now available from the built-in `@ember/test-helpers`