### PR TITLE
Revert to default ember-data ajax behavior

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,10 +1,9 @@
 import DS from 'ember-data';
-import AdapterFetchMixin from 'ember-fetch/mixins/adapter-fetch';
 import ENV from 'nanowrimo/config/environment';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 
-export default DS.JSONAPIAdapter.extend(AdapterFetchMixin, {
+export default DS.JSONAPIAdapter.extend({
   session: service(),
 
   host: ENV.APP.API_HOST,


### PR DESCRIPTION
Avoids clobbering of the Content-type header as described here: https://github.com/ember-cli/ember-fetch/issues/87