### PR TITLE
Clean up Mirage factories for consistency

### DIFF
--- a/mirage/factories/external-link.js
+++ b/mirage/factories/external-link.js
@@ -2,6 +2,6 @@ import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
   url() {
-    return `${faker.internet.url()}/${faker.internet.userName()}`
+    return `${faker.internet.url()}/${faker.internet.userName()}`;
   }
 });

--- a/mirage/factories/favorite-author.js
+++ b/mirage/factories/favorite-author.js
@@ -1,7 +1,5 @@
 import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  name() {
-    return faker.name.findName();
-  }
+  name: faker.name.findName
 });

--- a/mirage/factories/favorite-book.js
+++ b/mirage/factories/favorite-book.js
@@ -1,7 +1,5 @@
 import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  title() {
-    return faker.commerce.productName();
-  }
+  title: faker.commerce.productName
 });

--- a/mirage/factories/fundometer.js
+++ b/mirage/factories/fundometer.js
@@ -1,16 +1,14 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
   goalNumber() {
-    return 1400000;
-    //return 100000*faker.random.number({ min: 10, max: 20 });
+    let hundos = faker.random.number({ min: 10, max: 20 });
+    return 100000 * hundos;
   },
   raisedNumber() {
-    return 123345;
-    //return faker.random.number({ min: 0, max: 2000000 });
+    return faker.random.number({ min: 0, max: this.goalNumber });
   },
   donorNumber() {
-    return 1500;
-    //return faker.random.number({ min: 0, max: 5000 });
+    return faker.random.number({ min: 1, max: 5000 });
   }
 });

--- a/mirage/factories/genre.js
+++ b/mirage/factories/genre.js
@@ -1,7 +1,5 @@
 import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  name() {
-    return faker.company.bsBuzz();
-  }
+  name: faker.company.bsBuzz
 });

--- a/mirage/factories/project.js
+++ b/mirage/factories/project.js
@@ -1,22 +1,18 @@
 import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  name() {
-    return faker.commerce.productName();
-  },
+  name: faker.commerce.productName,
   count() {
-    return 10000 + Math.floor(Math.random() * 40000);
+    return faker.random.number({ min: 10000, max: 50000 });
   },
-  cover() {
-    let critters = ['dog','cat','bird','horse']
-    let key = critters[Math.floor(Math.random()*critters.length)];
-    return `https://loremflickr.com/240/320/${key}?random=1`;
+  cover(i) {
+    return `https://loremflickr.com/240/320/dog,cat,bird,horse?random=${i}`;
   },
   status() {
-    let stati =['Completed', 'In Progress']
-    return stati[Math.floor(Math.random()*stati.length)];
+    return faker.list.random('Completed', 'In Progress');
   },
-  createdAt(i) {
-    return faker.list.cycle('2015-11-01','2013-11-01','2016-11-01','2017-11-01')(i);
+  createdAt() {
+    let year = faker.list.cycle('2013', '2015', '2016', '2017');
+    return `${year}-11-01`;
   }
 });

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -2,64 +2,41 @@ import { Factory, faker } from 'ember-cli-mirage';
 import { uniq } from 'lodash';
 
 export default Factory.extend({
-  avatar() {
-    return faker.image.avatar();
-  },
+  avatar:faker.image.avatar,
   bio() {
     return faker.lorem.sentences(20);
   },
-  createdAt() {
-    return faker.date.past();
-  },
-  email() {
-    return faker.internet.email();
-  },
+  createdAt: faker.date.past,
+  email: faker.internet.email,
   location() {
     return `${faker.address.city()}, ${faker.address.stateAbbr()}`;
   },
-  name() {
-    return faker.internet.userName();
+  name: faker.internet.userName,
+  plate(i) {
+    return `https://loremflickr.com/1200/320/nature?random=${i}`;
   },
-  plate() {
-    return faker.image.nature();
-  },
-  postalCode() {
-    return faker.address.zipCode();
-  },
-
-  statsStreakEnabled() {
-    return faker.random.boolean();
-  },
+  postalCode: faker.address.zipCode,
+  statsStreakEnabled: faker.random.boolean,
   statsStreak() {
     return faker.random.number({ min: 10, max: 60 });
   },
-  statsProjectsEnabled() {
-    return faker.random.boolean();
-  },
+  statsProjectsEnabled: faker.random.boolean,
   statsProjects() {
     return faker.random.number({ min: 2, max: 10 });
   },
-  statsWordCountEnabled() {
-    return faker.random.boolean();
-  },
+  statsWordCountEnabled: faker.random.boolean,
   statsWordCount() {
     return faker.random.number({ min: 1000, max: 1000000 });
   },
-  statsWordiestEnabled() {
-    return faker.random.boolean();
-  },
+  statsWordiestEnabled: faker.random.boolean,
   statsWordiest() {
     return faker.random.number({ min: 10000, max: 100000 });
   },
-  statsWritingPaceEnabled() {
-    return faker.random.boolean();
-  },
+  statsWritingPaceEnabled: faker.random.boolean,
   statsWritingPace() {
     return faker.random.number({ min: 100, max: 10000 });
   },
-  statsYearsEnabled() {
-    return faker.random.boolean();
-  },
+  statsYearsEnabled: faker.random.boolean,
   statsYearsDone() {
     let numberOfYears = faker.random.number({ min: 3, max: 10 });
     let yearList = [];
@@ -73,5 +50,7 @@ export default Factory.extend({
     let yearsWon = yearsDone.filter(() => faker.random.boolean());
     return yearsWon.join(' ');
   },
-  timeZone: "America/Los_Angeles"
+  timeZone() {
+    return faker.list.random('America/New_York', 'America/Chicago', 'America/Denver', 'America/Los_Angeles');
+  }
 });


### PR DESCRIPTION
- When using a faker function with default options, use `property: faker.function` (no trailing `()` or every instance will have the same value)
- When using a faker function with custom options, use `property() { return faker.function({opts}); }`
- For images, use loremflickr directly as its performance is better than `faker.image`'s use of lorempixel. End the loremflickr URL with `?random=${i}` to avoid caching duplication. Note that giving loremflickr a comma-separated list of terms operates as an OR query, so we don't typically need to use faker randomness for these.
- When needing to generate values that faker doesn't provide directly but have some aspect of randomness, leverage faker to do the random bits wherever possible.
