### PR TITLE
Make model definitions more consistent

### DIFF
--- a/app/models/challenge.js
+++ b/app/models/challenge.js
@@ -1,12 +1,19 @@
 import DS from 'ember-data';
 
-export default DS.Model.extend({
-  name: DS.attr('string'),
-  event_type: DS.attr('string'),
-  unit_type: DS.attr('string'),
-  startsOn: DS.attr('date'),
-  defaultGoal: DS.attr('number'),
-  projects: DS.hasMany('project'),
-  primaryChallengeProjects: DS.hasMany('project', { inverse: 'primaryChallenge' }),
-  flexibleGoal: DS.attr('boolean')
+const {
+  Model,
+  attr,
+  hasMany
+} = DS;
+
+export default Model.extend({
+  defaultGoal: attr('number'),
+  eventType: attr('string'),
+  flexibleGoal: attr('boolean'),
+  name: attr('string'),
+  startsOn: attr('date'),
+  unitType: attr('string'),
+
+  primaryChallengeProjects: hasMany('project', { inverse: 'primaryChallenge' }),
+  projects: hasMany('project')
 });

--- a/app/models/external-link.js
+++ b/app/models/external-link.js
@@ -6,11 +6,12 @@ import Changeset from 'ember-changeset';
 import ENV from 'nanowrimo/config/environment';
 
 const {
+  Model,
   attr,
   belongsTo
 } = DS;
 
-export default DS.Model.extend({
+export default Model.extend({
   url: attr('string'),
 
   user: belongsTo(),
@@ -77,4 +78,3 @@ export default DS.Model.extend({
     }
   }
 });
-

--- a/app/models/favorite-author.js
+++ b/app/models/favorite-author.js
@@ -5,11 +5,12 @@ import { isPresent }  from '@ember/utils';
 import Changeset from 'ember-changeset';
 
 const {
+  Model,
   attr,
   belongsTo
 } = DS;
 
-export default DS.Model.extend({
+export default Model.extend({
   name: attr('string'),
 
   user: belongsTo(),

--- a/app/models/favorite-book.js
+++ b/app/models/favorite-book.js
@@ -5,11 +5,12 @@ import { isPresent }  from '@ember/utils';
 import Changeset from 'ember-changeset';
 
 const {
+  Model,
   attr,
   belongsTo
 } = DS;
 
-export default DS.Model.extend({
+export default Model.extend({
   title: attr('string'),
 
   user: belongsTo(),

--- a/app/models/fundometer.js
+++ b/app/models/fundometer.js
@@ -1,7 +1,12 @@
 import DS from 'ember-data';
 
-export default DS.Model.extend({
-  goalNumber: DS.attr('number'),
-  raisedNumber: DS.attr('number'),
-  donorNumber: DS.attr('number')
+const {
+  Model,
+  attr
+} = DS;
+
+export default Model.extend({
+  donorNumber: attr('number'),
+  goalNumber: attr('number'),
+  raisedNumber: attr('number')
 });

--- a/app/models/genre.js
+++ b/app/models/genre.js
@@ -1,7 +1,13 @@
 import DS from 'ember-data';
 
-export default DS.Model.extend({
-  name: DS.attr('string', { defaultValue: '' }),
+const {
+  Model,
+  attr,
+  hasMany
+} = DS;
 
-  projects: DS.hasMany('project')
+export default Model.extend({
+  name: attr('string', { defaultValue: '' }),
+
+  projects: hasMany('project')
 });

--- a/app/models/password-reset-attempt.js
+++ b/app/models/password-reset-attempt.js
@@ -1,6 +1,11 @@
 import DS from 'ember-data';
 
-export default DS.Model.extend({
-  token: DS.attr('string', { defaultValue: '' }),
-  password: DS.attr('string', { defaultValue: '' })
+const {
+  Model,
+  attr
+} = DS;
+
+export default Model.extend({
+  password: attr('string', { defaultValue: '' }),
+  token: attr('string', { defaultValue: '' })
 });

--- a/app/models/project-challenge.js
+++ b/app/models/project-challenge.js
@@ -1,7 +1,11 @@
 import DS from 'ember-data';
 
-export default DS.Model.extend({
+const {
+  Model,
+  belongsTo
+} = DS;
 
-  project: DS.belongsTo('project'),
-  challenge: DS.belongsTo('challenge')
+export default Model.extend({
+  challenge: belongsTo('challenge'),
+  project: belongsTo('project')
 });

--- a/app/models/project-genre.js
+++ b/app/models/project-genre.js
@@ -1,7 +1,11 @@
 import DS from 'ember-data';
 
-export default DS.Model.extend({
+const {
+  Model,
+  belongsTo
+} = DS;
 
-  project: DS.belongsTo('project'),
-  genre: DS.belongsTo('genre')
+export default Model.extend({
+  genre: belongsTo('genre'),
+  project: belongsTo('project')
 });

--- a/app/models/sign-in-attempt.js
+++ b/app/models/sign-in-attempt.js
@@ -1,6 +1,11 @@
 import DS from 'ember-data';
 
-export default DS.Model.extend({
-  email: DS.attr('string', { defaultValue: '' }),
-  password: DS.attr('string', { defaultValue: '' })
+const {
+  Model,
+  attr
+} = DS;
+
+export default Model.extend({
+  email: attr('string', { defaultValue: '' }),
+  password: attr('string', { defaultValue: '' })
 });

--- a/app/models/sign-up-attempt.js
+++ b/app/models/sign-up-attempt.js
@@ -1,13 +1,18 @@
 import DS from 'ember-data';
 import moment from 'moment';
 
-export default DS.Model.extend({
-  email: DS.attr('string', { defaultValue: '' }),
-  password: DS.attr('string', { defaultValue: '' }),
-  username: DS.attr('string', { defaultValue: '' }),
-  thirteen: DS.attr('boolean',{ defaultValue: false } ),
-  terms: DS.attr('boolean',{ defaultValue: false } ),
-  timeZone: DS.attr('string', {
+const {
+  Model,
+  attr
+} = DS;
+
+export default Model.extend({
+  email: attr('string', { defaultValue: '' }),
+  password: attr('string', { defaultValue: '' }),
+  terms: attr('boolean',{ defaultValue: false } ),
+  thirteen: attr('boolean',{ defaultValue: false } ),
+  timeZone: attr('string', {
     defaultValue() { return moment.tz.guess(); }
-  })
+  }),
+  username: attr('string', { defaultValue: '' })
 });

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -3,11 +3,12 @@ import { computed }  from '@ember/object';
 import { alias }  from '@ember/object/computed';
 
 const {
+  Model,
   attr,
   hasMany
 } = DS;
 
-export default DS.Model.extend({
+export default Model.extend({
   avatar: attr('string'),
   bio: attr('string'),
   createdAt: attr('date'),


### PR DESCRIPTION
- Destructure `DS` (results in a more module-like syntax that ember-data does plan to eventually support directly like Ember.js does)
- List attributes first, sorted alphabetically; use camelCase for all attributes
- List relationships next, sorted alphabetically
- List computed properties last (grouped alphabetically; single-line CPs then multi-line CPs)