### PR TITLE
Announce Project

### DIFF
--- a/app/components/challenge-editor.js
+++ b/app/components/challenge-editor.js
@@ -1,0 +1,30 @@
+import Component from '@ember/component';
+import { computed }  from '@ember/object';
+import { inject as service } from '@ember/service';
+import Changeset from 'ember-changeset';
+import Challenge from 'nanowrimo/models/challenge';
+
+export default Component.extend({
+  store: service(),
+
+  tagName: '',
+
+  challenge: null,
+
+  optionsForEventType: computed(function() {
+    return Challenge.optionsForEventType;
+  }),
+  optionsForUnitType: computed(function() {
+    return Challenge.optionsForUnitType;
+  }),
+
+  init() {
+    this._super(...arguments);
+    let challenge = this.get('challenge');
+    if (!challenge) {
+      challenge = this.get('store').createRecord('challenge');
+      this.set('challenge', challenge);
+    }
+    this.set('changeset', new Changeset(challenge));
+  }
+});

--- a/app/components/project-list-progress.js
+++ b/app/components/project-list-progress.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { computed, get } from '@ember/object';
 import moment from 'moment';
 
 export default Component.extend({
@@ -10,7 +10,7 @@ export default Component.extend({
   formattedStart: computed("project.challenges.[]", function(){
     let proj = this.get('project');
     if (proj) {
-      let start = proj.challenges.firstObject.startsOn;
+      let start = get(proj, 'challenges.firstObject.startsOn');
       let time = moment(start);
       if (time.month()===4) {
         //may does not need to be formatted with a period
@@ -25,7 +25,7 @@ export default Component.extend({
     let proj = this.get('project');
     if (proj) {
       //let dc = proj.displayChallenge;
-      return proj.challenges.firstObject.defaultGoal;
+      return get(proj, 'challenges.firstObject.defaultGoal');
     } else {
       return 0;
     }
@@ -33,8 +33,8 @@ export default Component.extend({
   goalMet: computed("percentCompleted", function(){
     return this.get('percentCompleted') === 100;
   }),
-  
-  
+
+
   percentCompleted: computed("goal","project.unitCount",function(){
     let proj = this.get('project');
     if (proj) {

--- a/app/components/project-new-modal.js
+++ b/app/components/project-new-modal.js
@@ -1,0 +1,57 @@
+import Component from '@ember/component';
+import { assert } from '@ember/debug';
+import { computed }  from '@ember/object';
+import { inject as service } from '@ember/service';
+import Project from 'nanowrimo/models/project';
+
+export default Component.extend({
+  store: service(),
+
+  tagName: '',
+
+  challenge: null,
+  tab: null,
+  open: null,
+  project: null,
+  user: null,
+
+  optionsForGenres: computed(function() {
+    return this.get('store').findAll('genre');
+  }),
+  optionsForPrivacy: computed(function() {
+    return Project.optionsForPrivacy;
+  }),
+  optionsForStatus: computed(function() {
+    return Project.optionsForStatus;
+  }),
+  optionsForWritingType: computed(function() {
+    return Project.optionsForWritingType;
+  }),
+
+  steps: computed(function() {
+    return [
+      ['title', 'status', 'privacy', 'writingType'],
+      [],
+      ['wordCount', 'summary', 'excerpt', 'pinterest', 'playlist']
+    ]
+  }),
+
+  init() {
+    this._super(...arguments);
+    let user = this.get('user');
+    assert('Must pass a user into {{project-new-modal}}', user);
+    let newProject = this.get('store').createRecord('project', { user });
+    this.set('project', newProject);
+  },
+
+  actions: {
+    onHidden() {
+      let callback = this.get('onHidden');
+      if (callback) {
+        callback();
+      } else {
+        this.set('open', null);
+      }
+    }
+  }
+});

--- a/app/controllers/authenticated/users/show/projects/index.js
+++ b/app/controllers/authenticated/users/show/projects/index.js
@@ -1,24 +1,43 @@
 import Controller from '@ember/controller';
+import { computed }  from '@ember/object';
 import { alias, sort } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+
 export default Controller.extend({
+  currentUser: service(),
+
+  queryParams: ['addProject'],
+
+  addProject: false,
   projects: alias('model'),
   sortedProjects: sort('projects', 'selectedSortOption'),
   sortOptions: null,
   selectedSortOption: null,
-  
-  actions: {
-    newProject(){
-      //console.log('new project');
-    },
-    setSortSelection(val) {
-       this.set('selectedSortOption', [val]);
-    }
-  },
-  
+  user: null,
+
+  canAddProject: computed('currentUser.user.id', 'user.id', function() {
+    return this.get('currentUser.user.id') === this.get('user.id');
+  }),
+
   init() {
     this._super(...arguments);
     let options = ['createdAt:desc', 'name'];
     this.set('sortOptions', options);
     this.set('selectedSortOption', [options[0]]);
+  },
+
+  actions: {
+    afterProjectModalClose() {
+      this.set('addProject', null);
+      this.send('refreshModel');
+    },
+    openNewProjectModal() {
+      if (this.get('canAddProject')) {
+        this.set('addProject', true);
+      }
+    },
+    setSortSelection(val) {
+       this.set('selectedSortOption', [val]);
+    }
   }
 });

--- a/app/helpers/is-equal.js
+++ b/app/helpers/is-equal.js
@@ -1,7 +1,0 @@
-import { helper } from '@ember/component/helper';
-
-export function isEqual(params/*, hash*/) {
-  return params[0] === params[1];
-}
-
-export default helper(isEqual);

--- a/app/models/challenge.js
+++ b/app/models/challenge.js
@@ -2,8 +2,9 @@ import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { hasMany } from 'ember-data/relationships';
 
-export default Model.extend({
+const Challenge = Model.extend({
   defaultGoal: attr('number'),
+  endsOn: attr('date'),
   eventType: attr('string'),
   flexibleGoal: attr('boolean'),
   name: attr('string'),
@@ -13,3 +14,16 @@ export default Model.extend({
   primaryChallengeProjects: hasMany('project', { inverse: 'primaryChallenge' }),
   projects: hasMany('project')
 });
+
+Challenge.reopenClass({
+  optionsForEventType: [
+    'Writing',
+    'Editing'
+  ],
+  optionsForUnitType: [
+    'words',
+    'hours'
+  ]
+});
+
+export default Challenge;

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -2,21 +2,24 @@ import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo, hasMany } from 'ember-data/relationships';
 import { computed } from '@ember/object';
-import { isEmpty } from '@ember/utils';
-  
-export default Model.extend({
+// import { isEmpty } from '@ember/utils';
+
+const Project = Model.extend({
   cover: attr('string'),
   createdAt: attr('date'),
   excerpt: attr('string'),
-  pinterest_url: attr('string'),
-  playlist_url: attr('string'),
+  pinterestUrl: attr('string'),
+  playlistUrl: attr('string'),
+  primary: attr('boolean'),
+  privacy: attr('string', { defaultValue: 'Only I Can See' }),
   slug: attr('string'),
   summary: attr('string'),
-  status: attr('string'),
+  status: attr('string', { defaultValue: 'In Progress' }),
   title: attr('string'),
   unitCount: attr('number'),
   unitType: attr('string'),
-  writingType: attr('string'),
+  wordCount: attr('number'),
+  writingType: attr('string', { defaultValue: 'Novel' }),
 
   challenges: hasMany('challenge'),
   genres: hasMany('genre'),
@@ -25,6 +28,7 @@ export default Model.extend({
   completed: computed('status', function() {
     return this.get('status') === "Completed";
   }),
+
   concatGenres: computed('genres.[]', function() {
     let genreNames = this.get('genres').mapBy('name');
     return genreNames.join(", ");
@@ -34,9 +38,24 @@ export default Model.extend({
     //console.log(tz);
   }),
   relationshipErrors: computed('genres.[]', function() {
-    if (isEmpty(this.get('genres'))) {
-      return { genres: 'Must select at least one genre' };
-    }
+    // if (isEmpty(this.get('genres'))) {
+    //   return { genres: 'Must select at least one genre' };
+    // }
     return null;
   })
 });
+
+Project.reopenClass({
+  optionsForStatus: [
+    'In Progress',
+    'Completed'
+  ],
+  optionsForPrivacy: [
+    'Only I Can See'
+  ],
+  optionsForWritingType: [
+    'Novel'
+  ]
+});
+
+export default Project;

--- a/app/routes/authenticated/users/show/projects/index.js
+++ b/app/routes/authenticated/users/show/projects/index.js
@@ -4,10 +4,19 @@ export default Route.extend({
   model() {
     let user = this.modelFor('authenticated.users.show');
     return this.get('store').query('project', {
-      filter: { user_id: user.id},
-      include: 'genres,challenges,project-challenges'}
-    ).then(function(projects){
-      return projects;
+      filter: { user_id: user.id },
+      include: 'genres,challenges,project-challenges'
     });
+  },
+
+  setupController(controller, model) {
+    this._super(controller, model);
+    controller.set('user', this.modelFor('authenticated.users.show'));
+  },
+
+  actions: {
+    refreshModel() {
+      this.refresh();
+    }
   }
 });

--- a/app/templates/authenticated/users/show/projects/index.hbs
+++ b/app/templates/authenticated/users/show/projects/index.hbs
@@ -1,12 +1,21 @@
-<div id='project-listing-panel' class="nano-panel right-resize with-tabs">
+<div id="project-listing-panel" class="nano-panel right-resize with-tabs">
   <ul class="nano-panel-tabs">
-    <li>{{link-to 'Profile' 'authenticated.users.show.index'}}</li>
-    <li>{{link-to 'Projects' 'authenticated.users.show.projects' }}</li>
-    <li>{{link-to 'Buddies' 'authenticated.users.show.buddies' }}</li>
+    <li>{{link-to "Profile" "authenticated.users.show.index"}}</li>
+    <li>{{link-to "Projects" "authenticated.users.show.projects"}}</li>
+    <li>{{link-to "Buddies" "authenticated.users.show.buddies"}}</li>
   </ul>
-  
   <div id='project-listing-actions'>
-    <button id='announce-new-project-button' {{action "newProject"}}>Announce New Project</button>
+    {{#if canAddProject}}
+      <button id="announce-new-project-button" {{action "openNewProjectModal"}} data-test-new-project>
+        Announce New Project
+      </button>
+
+      {{project-new-modal
+        onHidden=(action "afterProjectModalClose")
+        open=addProject
+        user=user
+      }}
+    {{/if}}
     <div id='project-listing-sort' >
       <label id='project-listing-sort-by-text' for='sort-by'>Sort by</label>
       <span id='project-listing-sort-by-select'>
@@ -18,22 +27,27 @@
     </div>
   </div>
 
-  {{#each sortedProjects as |project|}}
-    {{project-listing project=project}}
-  {{/each}}  
-  <div class="nano-card prompt-card short-card g3-hspan3 g2-hspan2">
-    <div class="nano-subcard">
-      <div class="nano-subcard-face">
-        <div class="nano-subcard-content side-by-side">
-          <div class="side-by-side-even">
-            <div>"A journey of a thousand miles<br>begins with a single step."<br /><span class="quotee">Lao Tzu</span></div>
-          </div>
-          <div class="side-by-side-even">
-            <a href="#" {{action "newProject"}}>Announce a new project!</a>
-            <img src='/images/users/projects/megaphone.svg' class="prompt-image">
+  <div data-test-project-list>
+    {{#each sortedProjects as |project|}}
+      {{project-listing project=project}}
+    {{/each}}
+  </div>
+
+  {{#if canAddProject}}
+    <div class="nano-card prompt-card short-card g3-hspan3 g2-hspan2">
+      <div class="nano-subcard">
+        <div class="nano-subcard-face">
+          <div class="nano-subcard-content side-by-side">
+            <div class="side-by-side-even">
+              <div>"A journey of a thousand miles<br>begins with a single step."<br /><span class="quotee">Lao Tzu</span></div>
+            </div>
+            <div class="side-by-side-even">
+              <a href="#" {{action "openNewProjectModal"}}>Announce a new project!</a>
+              <img src="/images/users/projects/megaphone.svg" class="prompt-image">
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  {{/if}}
 </div>

--- a/app/templates/components/challenge-editor.hbs
+++ b/app/templates/components/challenge-editor.hbs
@@ -1,0 +1,37 @@
+<div class="form-group">
+  {{form-for--select
+    changeset=changeset
+    label="What type of goal is this?"
+    options=optionsForEventType
+    property="eventType"
+  }}
+</div>
+<div class="form-group">
+  {{form-for--input
+    changeset=changeset
+    label="What is your goal?"
+    property="defaultGoal"
+  }}
+</div>
+<div class="form-group">
+  {{form-for--select
+    changeset=changeset
+    label=""
+    options=optionsForUnitType
+    property="unitType"
+  }}
+</div>
+<div class="form-group">
+  {{form-for--input
+    changeset=changeset
+    label="When do you start?"
+    property="startsOn"
+  }}
+</div>
+<div class="form-group">
+  {{form-for--input
+    changeset=changeset
+    label="When do you end?"
+    property="endsOn"
+  }}
+</div>

--- a/app/templates/components/form-for.hbs
+++ b/app/templates/components/form-for.hbs
@@ -2,13 +2,13 @@
   {{yield (hash
     currentStepIndex=currentStepIndex
     isLastStep=isLastStep
-    checkbox =( component 'form-for--checkbox' changeset=changeset hasAttemptedSubmit=hasAttemptedSubmit)
+    checkbox=(component 'form-for--checkbox' changeset=changeset hasAttemptedSubmit=hasAttemptedSubmit)
     hidden=(component 'form-for--hidden' changeset=changeset hasAttemptedSubmit=hasAttemptedSubmit)
     imageUpload=(component 'form-for--image-upload' changeset=changeset hasAttemptedSubmit=hasAttemptedSubmit)
     input=(component 'form-for--input' changeset=changeset hasAttemptedSubmit=hasAttemptedSubmit)
-    multiselect=( component 'form-for--multiselect' model=model hasAttemptedSubmit=hasAttemptedSubmit)
+    multiselect=(component 'form-for--multiselect' model=model hasAttemptedSubmit=hasAttemptedSubmit)
     password=(component 'form-for--password' changeset=changeset hasAttemptedSubmit=hasAttemptedSubmit)
-    select=( component 'form-for--select' changeset=changeset hasAttemptedSubmit=hasAttemptedSubmit)
-    textarea=( component 'form-for--textarea' changeset=changeset hasAttemptedSubmit=hasAttemptedSubmit)
+    select=(component 'form-for--select' changeset=changeset hasAttemptedSubmit=hasAttemptedSubmit)
+    textarea=(component 'form-for--textarea' changeset=changeset hasAttemptedSubmit=hasAttemptedSubmit)
   )}}
 </form>

--- a/app/templates/components/project-listing.hbs
+++ b/app/templates/components/project-listing.hbs
@@ -20,9 +20,9 @@
             {{project.concatGenres}}
           </div>
         </div>
-    
+
         {{project-list-progress project=project}}
-    
+
         <div class='project-status'>
           {{#if project.completed}}
             <img src="/images/users/projects/flippy-doodle-completed.png">

--- a/app/templates/components/project-new-modal.hbs
+++ b/app/templates/components/project-new-modal.hbs
@@ -1,0 +1,148 @@
+{{#bs-modal
+  open=open
+  onHidden=(action "onHidden")
+  as |modal|
+}}
+  {{#modal.header closeButton=false}}
+    This is a Great Start!
+  {{/modal.header}}
+  {{#form-for
+    data-test-project-form=true
+    afterSubmit=modal.close
+    model=project
+    steps=steps
+    as |f|
+  }}
+    {{#modal.body}}
+
+      <div class="row">
+        <div class="col-4 text-center">
+          {{#if (eq f.currentStepIndex 0)}}
+            <strong>Overview</strong>
+          {{else}}
+            <strike>Overview</strike>
+          {{/if}}
+        </div>
+        <div class="col-4 text-center">
+          {{#if (eq f.currentStepIndex 1)}}
+            <strong>Goal</strong>
+          {{else if (gt f.currentStepIndex 1)}}
+            <strike>Goal</strike>
+          {{else}}
+            Goal
+          {{/if}}
+        </div>
+        <div class="col-4 text-center">
+          {{#if f.isLastStep}}
+            <strong>Details</strong>
+          {{else}}
+            Details
+          {{/if}}
+        </div>
+      </div>
+
+      <div class="tab-content">
+
+        {{#if (eq f.currentStepIndex 0)}}
+
+          <div class="form-group">
+            {{f.input
+              label="What is the name of your project?"
+              property="title"
+            }}
+          </div>
+          <div class="form-group">
+            {{f.select
+              label="What is the project status?"
+              options=optionsForStatus
+              property="status"
+            }}
+          </div>
+          <div class="form-group">
+            {{f.select
+              label="How much privacy do you want?"
+              options=optionsForPrivacy
+              property="privacy"
+            }}
+          </div>
+          <div class="form-group">
+            {{f.select
+              label="What type of project is this?"
+              options=optionsForWritingType
+              property="writingType"
+            }}
+          </div>
+
+        {{else if (eq f.currentStepIndex 1)}}
+
+          {{challenge-editor challenge=challenge}}
+
+        {{else}}
+
+          <div class="form-group">
+            {{f.imageUpload
+              label="Add your cover art"
+              property="cover"
+            }}
+          </div>
+          <div class="form-group">
+            {{f.input
+              label="What is the current word count?"
+              property="wordCount"
+            }}
+          </div>
+          <div class="form-group">
+            {{f.multiselect
+              createOptionModel="genre"
+              label="What is/are the genre(s)?"
+              options=optionsForGenres
+              property="genres"
+              searchField="name"
+            }}
+          </div>
+          <div class="form-group">
+            {{f.textarea
+              label="Add a project summary"
+              property="summary"
+            }}
+          </div>
+          <div class="form-group">
+            {{f.textarea
+              label="Add an excerpt"
+              property="excerpt"
+            }}
+          </div>
+          <div class="form-group">
+            {{f.input
+              label="What is the project's Pinterest?"
+              placeholder="https://"
+              property="pinterestUrl"
+            }}
+          </div>
+          <div class="form-group">
+            {{f.input
+              label="What is the project's playlist?"
+              placeholder="https://"
+              property="playlistUrl"
+            }}
+          </div>
+          <div class="form-group">
+            {{f.checkbox
+              label="Make this my primary project"
+              property="primary"
+            }}
+          </div>
+
+        {{/if}}
+
+      </div>
+
+    {{/modal.body}}
+    {{#modal.footer}}
+
+      <input type="submit" class="btn-secondary btn-green" value={{if f.isLastStep "Save Project" (if (eq f.currentStepIndex 0) "On To Your Goal" "On To Details")}} data-test-project-submit />
+      <input type="button" class="btn-underlined" value="Cancel" {{action modal.close}} data-test-project-cancel />
+
+    {{/modal.footer}}
+  {{/form-for}}
+{{/bs-modal}}

--- a/app/templates/components/user-edit-bio-modal.hbs
+++ b/app/templates/components/user-edit-bio-modal.hbs
@@ -86,7 +86,7 @@
       {{/bs-tab}}
 
     {{/modal.body}}
-    {{#modal.footer tagName="div"}}
+    {{#modal.footer}}
 
       <input type="submit" class="nano-button" value="Save Details" data-test-user-bio-submit />
       <input type="button" class="nano-button btn-underlined" value="Cancel" {{action modal.close}} data-test-user-bio-cancel />

--- a/app/templates/components/user-edit-profile-modal.hbs
+++ b/app/templates/components/user-edit-profile-modal.hbs
@@ -81,7 +81,7 @@
       {{/bs-tab}}
 
     {{/modal.body}}
-    {{#modal.footer tagName="div"}}
+    {{#modal.footer}}
 
       <input type="submit" class="nano-button" value="Save Details" data-test-user-profile-submit />
       <input type="button" class="nano-button btn-underlined" value="Cancel" {{action modal.close}} data-test-user-profile-cancel />

--- a/app/templates/components/validated-time-zone.hbs
+++ b/app/templates/components/validated-time-zone.hbs
@@ -2,7 +2,7 @@
 <select id={{name}} name={{name}} class={{selectClasses}}
   onchange={{action (mut value) value="target.value"}}>
   {{#each timeZoneOptions as |option|}}
-    <option value={{option.value}} selected={{is-equal option.value value}}>
+    <option value={{option.value}} selected={{eq option.value value}}>
       {{option.name}}
     </option>
   {{/each}}

--- a/app/validations/project.js
+++ b/app/validations/project.js
@@ -1,7 +1,17 @@
 import {
+  validateFormat,
+  validateInclusion,
+  validateNumber,
   validatePresence
 } from 'ember-changeset-validations/validators';
+import Project from 'nanowrimo/models/project';
 
 export default {
-  name: validatePresence(true)
+  pinterestUrl: validateFormat({ allowBlank: true, type: 'url' }),
+  playlistUrl: validateFormat({ allowBlank: true, type: 'url' }),
+  privacy: validateInclusion({ list: Project.optionsForPrivacy }),
+  status: validateInclusion({ list: Project.optionsForStatus }),
+  title: validatePresence(true),
+  wordCount: validateNumber({ allowBlank: true, integer: true }),
+  writingType: validateInclusion({ list: Project.optionsForWritingType })
 };

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -46,6 +46,7 @@ export default function() {
 
   // CRUD
 
+  this.resource('challenges', { only: ['index'] });
   this.resource('external-links', { only: ['create', 'update'] });
   this.del('external-links/:id', ({ externalLinks }, request) => {
     let id = request.params.id;
@@ -64,7 +65,6 @@ export default function() {
     favoriteBooks.find(id).destroy();
     return { meta: {} };
   });
-
   this.resource('genre', { except: ['delete'] });
   this.del('genres/:id', ({ genres }, request) => {
     let id = request.params.id;
@@ -82,11 +82,13 @@ export default function() {
     let genreIds = attrs.genreIds;
     delete attrs.genreIds;
     let project = projects.create(attrs);
-    for (let i=0; i<genreIds.length; i++) {
-      projectGenres.create({
-        projectId: project.attrs.id,
-        genreId: genreIds[i]
-      });
+    if (genreIds) {
+      for (let i=0; i<genreIds.length; i++) {
+        projectGenres.create({
+          projectId: project.attrs.id,
+          genreId: genreIds[i]
+        });
+      }
     }
     return project;
   });

--- a/mirage/factories/project.js
+++ b/mirage/factories/project.js
@@ -1,6 +1,35 @@
 import { Factory, faker } from 'ember-cli-mirage';
+import Project from 'nanowrimo/models/project';
 
 export default Factory.extend({
+  cover(i) {
+    return `https://loremflickr.com/240/320/dog,cat,bird,horse?random=${i}`;
+  },
+  createdAt(i) {
+    let year = faker.list.cycle('2013', '2015', '2016', '2017')(i);
+    return `${year}-11-01`;
+  },
+  pinterestUrl() {
+    return `https://pinterest.com/${faker.internet.userName()}`;
+  },
+  playlistUrl() {
+    return `https://spotify.com/${faker.internet.userName()}`;
+  },
+  primary(i) {
+    return i === 1;
+  },
+  privacy() {
+    let options = Project.optionsForPrivacy;
+    return faker.list.random.apply(this, options)();
+  },
+  slug(i){
+    return "project-slug-"+i;
+  },
+  status() {
+    let options = Project.optionsForStatus;
+    return faker.list.random.apply(this, options)();
+  },
+  summary: faker.lorem.sentence,
   title: faker.commerce.productName,
   unitCount() {
     return faker.random.number({ min: 10000, max: 50000 });
@@ -8,16 +37,11 @@ export default Factory.extend({
   unitType() {
     return 'word';
   },
-  cover(i) {
-    return `https://loremflickr.com/240/320/dog,cat,bird,horse?random=${i}`;
+  wordCount() {
+    return faker.random.number({ min: 0, max: 5000 });
   },
-  slug(i){
-    return "project-slug-"+i; 
-  },
-  status: faker.list.random('Completed', 'In Progress'),
-  createdAt(i) {
-    let year = faker.list.cycle('2013', '2015', '2016', '2017')(i);
-    return `${year}-11-01`;
+  writingType() {
+    let options = Project.optionsForWritingType;
+    return faker.list.random.apply(this, options)();
   }
-  
 });

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -8,22 +8,15 @@ export default function(server) {
   server.createList('external-link', 2, { user });
   server.createList('favorite-book', 3, { user });
   server.createList('favorite-author', 3, { user });
-
-  // Prior demo; replace with realistic Projects and Genres
-  let projects = server.createList('project', 3, {user: user});
-  let genres = server.createList('genre', 5);
-  
+  let projects = server.createList('project', 3, { user });
   let challenge = server.create('challenge');
+  let genres = server.createList('genre', 5);
   projects.forEach(function(project) {
     server.create('project-challenge', { project, challenge });
     sampleSize(genres, 2).forEach(function(genre) {
       server.create('project-genre', { project, genre })
     });
   });
-  //set the first project to have a count of 50321
-  projects[0].count= 50321; 
-  
   server.createList('fundometer', 5);
   server.create('flash-banner');
-  
 }

--- a/tests/acceptance/project-announce-test.js
+++ b/tests/acceptance/project-announce-test.js
@@ -1,0 +1,56 @@
+import { module, test } from 'qunit';
+import { click, fillIn, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+module('Acceptance | project announce', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  let user;
+
+  hooks.beforeEach(function(/*assert*/) {
+    user = this.server.create('user');
+    authenticateSession();
+  });
+
+  test('announce new Project button only appears for self User', async function(assert) {
+    let otheruser = this.server.create('user');
+
+    await visit(`/participants/${otheruser.name}/projects`);
+
+    assert.dom('[data-test-new-project]').doesNotExist('no new Project button for other User');
+
+    await visit(`/participants/${user.name}/projects`);
+
+    assert.dom('[data-test-new-project]').exists('new Project button shown for self User');
+  });
+
+  test('announce a new Project', async function(assert) {
+    await visit(`/participants/${user.name}/projects`);
+    await click('[data-test-new-project]');
+
+    assert.dom('[data-test-project-form]').exists('form is shown');
+
+    let title = 'My New Project';
+    await fillIn('[data-test-form-for--input=title]', title);
+    await click('[data-test-project-submit]');
+
+    assert.dom('[data-test-project-form]').exists('form is still shown (Step 2)');
+
+    await click('[data-test-project-submit]');
+
+    assert.dom('[data-test-project-form]').exists('form is still shown (Step 3)');
+
+    await fillIn('[data-test-form-for--input=wordCount]', '1234');
+    await fillIn('[data-test-form-for--textarea=summary]', 'This is my summary.');
+    await fillIn('[data-test-form-for--textarea=excerpt]', 'This is my excerpt.');
+    await fillIn('[data-test-form-for--input=pinterestUrl]', 'https://pinterest.com/username');
+    await fillIn('[data-test-form-for--input=playlistUrl]', 'https://spotify.com/username');
+    await click('[data-test-project-submit]');
+
+    assert.dom('[data-test-project-form]').doesNotExist('form is dismissed');
+    assert.dom('[data-test-project-list]').includesText(title, 'new Project is shown in list');
+  });
+});


### PR DESCRIPTION
Clicking on the "Announce New Project" button on the Projects index page brings up a New Project modal that walks through 3 steps (Overview, Goals, Details):

![Overview](https://user-images.githubusercontent.com/250934/41383189-7bfe404a-6f3d-11e8-93c9-7a4d16512ba8.png)

![Goals](https://user-images.githubusercontent.com/250934/41385273-7b150cc6-6f48-11e8-945d-2b203023b0f4.png)

![Details](https://user-images.githubusercontent.com/250934/41385287-94ddd1ce-6f48-11e8-8d39-fcc34a8724c4.png)

A handful of stream-of-consciousness notes:

- General
  - [x] As displayed above, the three steps are noted at the top; the current step is **bold** and completed steps are ~strikethrough~; this should get the ball rolling on the progress styles shown on Zeplin.
  - [x] Saving the Project properties does persist the Project itself to the API and refresh the Projects index to include the newly created Project.
- Overview (Step 1)
  - [x] Name, status, privacy, and type properties are editable and validated.
  - [x] Note that the `<select>`s all leverage class-level properties on the Project model that define the list of options. These class properties (defined via `reopenClass`) are reused by both the component rendering the form and the validator checking selected options for inclusion. This is a pattern that I really like for model-specific configuration like this.
  - [ ] The ability to select an existing Challenge (or "Event") at this step needs to be implemented.
- Goal (Step 2)
  - [x] This step uses a `{{challenge-editor}}` component that creates a new Challenge in the store, creates a Changeset for the Challenge, and then renders form fields that exist independent from the Project model's `{{form-for}}`.
  - [ ] This Challenge does not yet get saved when the Project is ultimately created.
  - [ ] This step does not yet account for an existing Challenge that may get selected in Step 1.
- Details (Step 3)
  - [x] Form fields for all detail categories are present and editable in this step.
  - [ ] The `cover` image upload uses the same component as User avatar and plate uploads. If you really want this upload to only offer a "Browse" button as shown on Zeplin and not a drag-and-drop used elsewhere, I'd recommend adding a configuration option to the `{{form-for--image-upload}}` component to alter the display while still leveraging the internals of this component that perform the Rails ActiveStorage upload.
  - [ ] The Genre select here is using the same component and methods we had used in our previous foray into "attach or create" UI, but there is something buggy going on with it that needs to be tracked down. The internals to persist the Project to Genres relationships should still be in place.

I'll leave it up to you whether to merge this as-is and then work on addressing the above uncheked items or continue to work on this branch before merging.