### PR TITLE
Refactored loading of user data

### DIFF
--- a/app/controllers/authenticated/index.js
+++ b/app/controllers/authenticated/index.js
@@ -5,7 +5,9 @@ import { computed } from '@ember/object';
 export default Controller.extend({
   currentUser: service(),
   router: service(),
-
+  badgesService: service(),
+  notificationsService: service(),
+  
   currentUserName: reads('currentUser.user.name'),
   currentUserEmail: reads('currentUser.user.email'),
   currentUserIsNotConfirmed: reads('currentUser.user.isNotConfirmed'),
@@ -23,6 +25,21 @@ export default Controller.extend({
   queryParams: ['addProject'],
   
   addProject: false,
+  
+  init() {
+    this._super(...arguments);
+    this._loadBadgesService();
+    this._loadNotificationsService();
+  },
+
+  _loadBadgesService() {
+    return this.get('badgesService').load();
+  },
+  _loadNotificationsService() {
+    return this.get('notificationsService').load();
+  },
+
+  
   
   actions: {
     afterProjectModalClose() {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -5,8 +5,6 @@ import ENV from 'nanowrimo/config/environment';
 
 export default Route.extend(ApplicationRouteMixin, {
   currentUser: service(),
-  badgesService: service(),
-  notificationsService: service(),
   session: service(),
   //include the airbrake service 
   airbrake: service(),
@@ -42,27 +40,13 @@ export default Route.extend(ApplicationRouteMixin, {
     }
   },
 
-  beforeModel() {
-    this._loadBadgesService();
-    this._loadNotificationsService();
+  afterModel() {
     return this._loadCurrentUser();
   },
 
-  sessionAuthenticated() {
-    this._super(...arguments);
-    this._loadBadgesService();
-    this._loadNotificationsService();
-    this._loadCurrentUser();
-  },
 
   _loadCurrentUser() {
     return this.get('currentUser').load().catch(() => this.get('session').invalidate());
-  },
-  _loadBadgesService() {
-    return this.get('badgesService').load();
-  },
-  _loadNotificationsService() {
-    return this.get('notificationsService').load();
   },
 
   actions: {


### PR DESCRIPTION
Moved loading of Badges and Notifications to authenticated/index route
currentUser loading is now in the after_model hook