### PR TITLE
Styled link to forum email preferences

### DIFF
--- a/app/templates/authenticated/settings/preferences.hbs
+++ b/app/templates/authenticated/settings/preferences.hbs
@@ -77,8 +77,11 @@
         {{f.checkbox label="Writing reminders" property="emailWritingReminders"}}
       </div>-->
       {{#if forumsEmailPreferencesUrl}}
+        <br >
         <div class='form-group'>
-          <a href="{{forumsEmailPreferencesUrl}}">Forums Email Preferences</a>
+          <a href="{{forumsEmailPreferencesUrl}}" target="_blank" style="font-size:16px;">
+            Forums Email Preferences
+          </a>
         </div>
       {{/if}}
     </div>


### PR DESCRIPTION
font-size 16px
target _blank (opens in new tab/window)
add a line break prior to the link

refs nano 174