### PR TITLE
fixed bug where /stats was displaying bad data

### DIFF
--- a/app/components/project-stats.js
+++ b/app/components/project-stats.js
@@ -245,11 +245,13 @@ export default Component.extend({
    return this.get('projectChallenge.unitTypeSingular'); 
   }),
   
-  count: computed('challengeSessions.[]','project.projectSessions.[]', function() {
-    let sessions = this.get('challengeSessions');
+  count: computed('challengeSessions.[]', function() {
+    // get the sessions
+    let css = this.get('challengeSessions');
     let sum = 0;
-    if (sessions) {
-      sessions.forEach((s)=>{ sum+= s.count});
+    // are there sessions to process?
+    if (css) {
+      css.forEach((cs)=>{ sum+=cs.count});
     }
     return sum;
   }),


### PR DESCRIPTION
modified project-stats 'count' computed property to sum
the count of challengeSessions

refs API #291