### PR TITLE
Implemented sane defaults for project-session-modal

### DIFF
--- a/app/components/project-session-modal.js
+++ b/app/components/project-session-modal.js
@@ -121,6 +121,29 @@ export default Component.extend({
   // Session methods end
 
   actions: {
+    onShow() {
+      // the modal is being shown
+      //determine what should be displayed for date and times
+      // is the projectChallenge still active?
+      let pc = this.get('projectChallenge');
+      if (pc.hasEnded()) {
+        //set the session date to the last day of the event
+        this.set('dateStart',pc.endsAt);
+      } else {
+        //set the session date to the current date for the user
+        let tz = this.get('currentUser.user.timeZone');
+        let now = moment().tz(tz);
+        let formatted = now.format("YYYY-MM-DD");
+        this.set('dateStart',formatted);
+      }
+      //set defaults for the times
+      this.set('whenStart', "12:00");
+      this.set('whenEnd', "13:00");
+      
+      //set the 'count' to zero
+      this.set('countValue', 0);
+    },
+    
     // Session actions
     closeModal() {
        this.set('open', false);

--- a/app/templates/components/project-session-modal.hbs
+++ b/app/templates/components/project-session-modal.hbs
@@ -1,5 +1,6 @@
 {{#bs-modal
   open=open
+  onShow=(action "onShow")
   as |modal|
 }}
   {{#modal.header closeButton=false}}
@@ -93,6 +94,8 @@
               name='date'
               class='form-control'
               value=dateStart
+              min=projectChallenge.startsAt
+              max=projectChallenge.endsAt
             }}
           </div>
           <div style="flex: 0 0 80px; padding-right: 10px;">


### PR DESCRIPTION
updated template to call component's "onShow" action when modal is opened
updated component to create "onShow" action that sets defaults
for date, start and end times, and count

refs API#194