### PR TITLE
Fixed problems with the nano-winner-2019 route

### DIFF
--- a/app/components/splash-winner.js
+++ b/app/components/splash-winner.js
@@ -26,7 +26,7 @@ export default Component.extend({
   
   winnerRoute: computed('isNaNo', function(){
     let i = this.get('isNaNo');
-    let route = (i) ? "nano-winner-2019" : "authenticated.camp-nanowrimo-april-2020-winner";
+    let route = (i) ? "authenticated.nano-winner-2019" : "authenticated.camp-nanowrimo-april-2020-winner";
     return route;
   }),
   

--- a/app/router.js
+++ b/app/router.js
@@ -87,8 +87,10 @@ Router.map(function() {
     //dummy route to redirect to the forums
     this.route('forums');
     
-    //temporary route to camp-nanowrimo-april-2020-winner TODO: refactor to a generic winner route
+    /* TODO: refactor to a generic winner route */
+    //temporary route to camp-nanowrimo-april-2020-winner 
     this.route('camp-nanowrimo-april-2020-winner');
+    this.route('nano-winner-2019');
     
   });
 
@@ -117,7 +119,6 @@ Router.map(function() {
   
   
   this.route('404');
-  this.route('nano-winner-2019');
   this.route('not-found', { path: '/*path' });
   this.route('error');
   this.route('forgot-password');

--- a/app/routes/authenticated/nano-winner-2019.js
+++ b/app/routes/authenticated/nano-winner-2019.js
@@ -8,11 +8,13 @@ export default Route.extend({
   templateName: '404',
   model() {
     let cu = this.get('currentUser.user');
-    const winner = cu.currentEventWon;
-    let endpoint =  `${ENV.APP.API_HOST}/pages/nano-winner-2019?user_id=`+cu.get('id');
+    let winner = cu.wonEventByName("NaNoWriMo 2019");
     if (!winner) {
-      endpoint =  `${ENV.APP.API_HOST}/pages/how-to-win-nanowrimo`;
+      // return and the default 404 will be displayed
+      return;
     }
+
+    let endpoint =  `${ENV.APP.API_HOST}/pages/nano-winner-2019?user_id=`+cu.get('id');
     return fetch(endpoint).then((data)=>{
       return data.json().then((json)=>{
         return json;


### PR DESCRIPTION
refactored the determination of a "winner" to use
user.wonEventByName() method.

moved nano-winner-2019.js route to reuire authentication

display 404 if a non-winner views the route

refs API#383