### PR TITLE
Limit scroll styling to initial divs in project details

### DIFF
--- a/app/styles/theme/nw-card.scss
+++ b/app/styles/theme/nw-card.scss
@@ -502,6 +502,12 @@
 .nw-scrollable {
   overflow: scroll;
 }
+
+.nw-scroll-y {
+  overflow-y: scroll;
+  overflow-x: hidden;
+}
+
 .nw-noscroll {
   overflow: hidden;
 }

--- a/app/styles/theme/nw-project.scss
+++ b/app/styles/theme/nw-project.scss
@@ -141,7 +141,6 @@
 }
 .nw-project-details > div {
   flex: 0 0 37%;
-  overflow: scroll;
   padding: 10px;
   background-color: $nw-white-2;
   border-radius: 12px;

--- a/app/templates/components/project-flippy-details.hbs
+++ b/app/templates/components/project-flippy-details.hbs
@@ -10,9 +10,9 @@
       </div>
     </div>
     <div class='nw-card-content nw-project-details'>
-      <div class='nw-project-flippy-title'>
+      <div class='nw-project-flippy-title nw-scroll-y'>
         <div class='nw-promo-text'>{{project.title}}</div>
-        <div class='nw-noscroll'>
+        <div >
           <div class='nw-project-genres nw-horiz-flex'>
             {{project.concatGenres}}
           </div>
@@ -37,17 +37,17 @@
           </div>
         </div>
       </div>
-      <div>
+      <div class='nw-scroll-y'>
         <div class='nw-label'>Summary</div>
-        <div class='nw-noscroll'>
+        <div>
           {{#if project.summary}}
             {{{newline-to-br project.summary}}}
           {{/if}}
         </div>
       </div>
-      <div>
+      <div class='nw-scroll-y'>
         <div  class='nw-label'>Excerpt</div>
-        <div class='nw-noscroll'>
+        <div>
           {{#if project.excerpt}}
             {{{newline-to-br project.excerpt}}}
           {{/if}}


### PR DESCRIPTION
added .nw-scroll-y class to nw-card
removed `overflow: scroll;` from `.nw-project-details > div` class in
nw-project

modified project-flippy-details template to use new class

refs API 398