### PR TITLE
local development can use the staging API

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -143,7 +143,7 @@ module.exports = function(environment) {
   }
 
   //is this a staging target?
-  if (process.env.TARGET=='staging') {
+  if (process.env.TARGET=='staging' || environment==="dev-with-staging-api") {
     ENV.APP.API_HOST = 'https://staging.api.nanowrimo.org';
     ENV.torii.providers['custom-google'].redirectUri = 'https://staging.nanowrimo.org/oauth2callback';
     ENV.forumsUrl = "https://staging.forums.nanowrimo.org";


### PR DESCRIPTION
modified the environment file to allow local development to use the
staging API when running ember server with the dev-with-staging-api
environment.

From the ember source directory, run: ember s -e dev-wih-staging-api