### PR TITLE
break long words in chat messages

### DIFF
--- a/app/styles/theme/nanomessages.scss
+++ b/app/styles/theme/nanomessages.scss
@@ -39,7 +39,10 @@
       overflow-y: scroll;
       -webkit-transition: all 0.6s;
       transition: all 0.6s;
-
+      @media(max-width: $screen-sm) {
+        padding-left: 5px;
+        padding-right: 5px;
+      }
       .nanomessages-container {
         padding-top: 28px;
         -webkit-transition: all 0.6s;
@@ -89,6 +92,7 @@
               line-height: 1.25;
               text-align: left;
               color: $nw-darkgrey;
+              overflow-wrap: anywhere;
               img {
                 max-width: 100%;
               }


### PR DESCRIPTION
reduced left and right padding for conversation-content
on mobile

added overflow-wrap: anywhere to .nanomessage-content

refs API#459