### PR TITLE
improved goal reference for dashboard badges

### DIFF
--- a/app/templates/authenticated/index.hbs
+++ b/app/templates/authenticated/index.hbs
@@ -112,7 +112,7 @@
         {{/if}} 
         {{#if currentUserHasProject }}
           <div class="nw-card g3-col1 g3-row2 g3-hspan2 g3-vspan1 g2-col1 g2-row2 g2-hspan1 g2-vspan1">
-            {{badges-card cardTitle='Writing badges' badgeType='word count' user=currentUser.user projectChallenge=primaryProject.latestProjectChallenge}}
+            {{badges-card cardTitle='Writing badges' badgeType='word count' user=currentUser.user projectChallenge=primaryProject.currentProjectChallenge}}
           </div>
         {{else}}
           <div class="nw-card nw-prompt-card g3-col1 g3-row2 g3-hspan2 g3-vspan1 g2-col1 g2-row2 g2-hspan1 g2-vspan1">


### PR DESCRIPTION
use project.currentProjectChallenge to determine which badges to display on the
user's dashboard

refs API#508