### PR TITLE
Update badges without requiring an API request

### DIFF
--- a/app/controllers/authenticated/users/show/projects/show/badges.js
+++ b/app/controllers/authenticated/users/show/projects/show/badges.js
@@ -32,7 +32,7 @@ export default Controller.extend({
           this.set('_projectChallenge', pc);
           // update the badges data 
           let b = this.get('badgesService');
-          b.checkForUpdates();
+          b.incrementRecomputeBadges();
           break;
         }
       }


### PR DESCRIPTION
The badge data already exists. The computed property just needs the
badgesService to incrementRecompute

refs API#508