### PR TITLE
App loading indicator is *mostly* centered vertically and horizontally

### DIFF
--- a/app/styles/theme/general.scss
+++ b/app/styles/theme/general.scss
@@ -357,3 +357,10 @@ a.nw-grey-link {
 .fa-bullhorn {
   font-size: 60px;
 }
+
+#application-loading-indicator {
+  position: absolute;
+  top: 45%;
+  left: 45%;
+  text-align: center;
+}


### PR DESCRIPTION
refs https://github.com/nanowrimo/Issues-and-Actions/issues/138