### PR TITLE
Better detection of an event win and splash display

### DIFF
--- a/app/components/notifications-menu.js
+++ b/app/components/notifications-menu.js
@@ -18,12 +18,13 @@ export default Component.extend({
   badgeForSplash: null,
   displayNotifications: false,
   badgeExtraData: null,
-  
+  currentProjectChallenge: null,
   init(){
     this._super(...arguments);
     //access the 'currentUser.user.primaryProject.currentProjectChallenge.wonAt' for observing reasons
     let wonAt =this.get('currentUser.user.primaryProject.currentProjectChallenge.wonAt');
     this.set('oldWonAt', wonAt);
+    this.set('currentProjectChallenge', this.get('currentUser.user.primaryProject.currentProjectChallenge'));
   },
   allNotifications: computed('notificationsService.recomputeNotifications', function() {
     let ns = this.get('store').peekAll('notification');
@@ -59,14 +60,15 @@ export default Component.extend({
     else return "";
   }),
   
-  observePotentialWin: observer('currentUser.user.primaryProject.currentProjectChallenge.{winnerBadge}', function() {
+  observePotentialWin: observer('currentProjectChallenge.wonAt', function() {
+    let pc = this.get('currentProjectChallenge');
     // get the winner badge
-    let winnerBadge = this.get('currentUser.user.primaryProject.currentProjectChallenge.winnerBadge');
-    let wonAt = this.get('currentUser.user.primaryProject.currentProjectChallenge.wonAt');
+    let winnerBadge = pc.winnerBadge();
+    
+    let wonAt = pc.wonAt;
     //get the eventType 
-    let eventType = this.get('currentUser.user.primaryProject.currentProjectChallenge.eventType');
-    
-    
+    let eventType = pc.eventType;
+       
     // is this nano or camp?
     if (eventType<2 && wonAt && winnerBadge) {
       // get the current time in the user's timezone

--- a/app/components/splash-winner.js
+++ b/app/components/splash-winner.js
@@ -15,7 +15,9 @@ export default Component.extend({
   isNaNo: computed('badge', function() {
     //get the badge 
     let b = this.get('badge');
-    return !b.title.includes("Camp");
+    if (b) {
+      return !b.title.includes("Camp");
+    }
   }),
   
   winnerImage: computed('isNaNo', function(){

--- a/app/models/project-challenge.js
+++ b/app/models/project-challenge.js
@@ -349,24 +349,33 @@ const ProjectChallenge = Model.extend({
     });
   },
   
-  winnerBadge: computed('userBadges.[]', function(){
+  winnerBadge: function(){ 
+    let eType = this.get('eventType');
+    let titleKey;
+    switch (eType) {
+      case 0:
+        titleKey = "Wrote 50,000 Words In November";
+        break;
+      case 1:
+        titleKey = "Achieved Your Camp NaNoWriMo Goal";
+        break;
+      default:
+        return;
+    }
     //use the store
     let store = this.get('store');
-    // get the badges
-    let badges = store.peekAll('userBadge'); 
-    let id = parseInt(this.get('id')); 
-    let projectChallengeBadges = badges.filterBy('project_challenge_id', id);
-      let winnerBadge=null;
-    //loop
-    for (var i = 0; i < projectChallengeBadges.length; i++) {
-      var pcBadge = projectChallengeBadges[i];
-      var badge = store.peekRecord('badge', pcBadge.badge_id);
-      if (badge && badge.winner) {
-        return badge;
+    // get the badges 
+    let badges = store.peekAll('badge');
+    let winnerBadges = badges.filterBy("winner", true);
+    let winnerBadge;
+    // loop through the winnerbadges 
+    winnerBadges.forEach((badge)=>{
+      if (badge.title == titleKey) {
+        winnerBadge = badge;
       }
-    }
+    });
     return winnerBadge;
-  })
+  }
   
 });
 

--- a/app/services/badges-service.js
+++ b/app/services/badges-service.js
@@ -14,9 +14,9 @@ export default Service.extend({
   },
   
   getBaseBadgeData() {
-    let t = this;
+    //let t = this;
     this.get('store').query('badge',{}).then(function() {
-      debounce(t, t.checkForUpdates, 1000, false);
+      //debounce(t, t.checkForUpdates, 1000, false);
     });
   },
   

--- a/app/services/ping-service.js
+++ b/app/services/ping-service.js
@@ -27,6 +27,8 @@ export default Service.extend({
   
   load() {
     if (this.get('session.isAuthenticated')) {
+      // load the initial badge data 
+      this.get('badgesService').getBaseBadgeData();
       this.loopApiRequest();
     }
   },


### PR DESCRIPTION
modified notification-menu to simplify checking for a potential win
modified splash-winner to check a badges title only if the badge exists
modified project-challenge model to return the challenges winner badge
modified badge-service to not check for updates when loading base badge data
modified ping-service to trigger badgeService.getBaseBadgeData on init

refs https://github.com/nanowrimo/Issues-and-Actions/issues/135