### PR TITLE
Remove a rejected event from the pending event list

### DIFF
--- a/app/components/event-listing.js
+++ b/app/components/event-listing.js
@@ -94,13 +94,14 @@ export default Component.extend({
   },
     
   doReject() {
+    // set the event's approvedById to -1 to signify rejection
     let e = this.get('event');
     let uid = -1;
     e.set("approvedById",uid);
     e.save().then(()=>{
       // Increment recompute location
-      let re = this.get('recomputeEvents');
-      this.set('recomputeEvents',re+1);
+      //let re = this.get('recomputeEvents');
+     // this.set('recomputeEvents',re+1);
     });
   },
     

--- a/app/controllers/authenticated/regions/show/events/pending.js
+++ b/app/controllers/authenticated/regions/show/events/pending.js
@@ -24,7 +24,8 @@ export default Controller.extend({
     let pe = [];
     let now = moment();
     gs.forEach(function(g) {
-      if ((g.groupId==gid) && (g.endDt>now) && (g.approvedById<1)) {
+      // is the event a pending event for this group? 
+      if ((g.groupId==gid) && (g.endDt>now) && (g.approvedById===0)) {
         pe.push(g);
       }
     });


### PR DESCRIPTION
modified pending to controller to not include rejected events in the pending list
modified event-listing to remove code that was throwing errors when a rejected event was removed from the list

refs #https://github.com/nanowrimo/Issues-and-Actions/issues/272